### PR TITLE
fix: enable @nestjs use with version 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,8 @@
         "typescript": "^4.7.3"
       },
       "peerDependencies": {
-        "@nestjs/common": "8.x",
-        "@nestjs/core": "8.x"
+        "@nestjs/common": "8.x - 9.x",
+        "@nestjs/core": "8.x - 9.x"
       }
     },
     "node_modules/@aduh95/viz.js": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "node-rfc": "^2.5.1"
   },
   "peerDependencies": {
-    "@nestjs/common": "8.x",
-    "@nestjs/core": "8.x"
+    "@nestjs/common": "8.x - 9.x",
+    "@nestjs/core": "8.x - 9.x"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: <https://www.conventionalcommits.org/en/v1.0.0/>
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

Enable the use of this library with @nestjs version 9

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?

When using this library with @nestjs 9, it's needed to --force the install because of the peerDependencies configuration that restricts only version 8.

Issue Number: N/A

## What is the new behavior?

Enabling use of @nestjs 9, already being used at https://github.com/grupoboticario/franchising-eccutil-integration-api/tree/feature/API-1339 but with --force param when installing

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

